### PR TITLE
feat: ExpressionField и другие

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
+## 0.1.7
+
+### Добавлено:
+- Макет класса `\Bitrix\Main\ORM\Fields\ExpressionField`
+- Расширены `\Bitrix\Main\DB\SqlExpression`, `\Bitrix\Main\ORM\Fields\ScalarField`,
+    `\WebArch\BitrixTaxidermist\Mock\Bitrix\Main\ORM\Fields\Field`
+
 ## 0.1.6
+
 ### Добавлено:
 - Добавлены методы `CDBResultMysql::Fetch()` и `\Bitrix\Main\ORM\Query\Query::setLimit()`
 

--- a/src/main/Mock/Bitrix/Main/DB/SqlExpression.php
+++ b/src/main/Mock/Bitrix/Main/DB/SqlExpression.php
@@ -1,9 +1,38 @@
 <?php
+/** @noinspection PhpDocRedundantThrowsInspection */
 
 namespace WebArch\BitrixTaxidermist\Mock\Bitrix\Main\DB;
 
+use WebArch\BitrixTaxidermist\Mock\Bitrix\Main\ArgumentException;
+
 class SqlExpression
 {
+    /** @var string */
+    protected $expression;
+
+    /** @var array */
+    protected $args = [];
+
+    protected $pattern = '/([^\\\\]|^)(\?[#sif]?)/';
+
+    protected $i;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @param string $expression Sql expression.
+     * @param string,... $args Substitutes.
+     *
+     * @throws ArgumentException
+     * @noinspection PhpDocSignatureInspection
+     */
+    public function __construct(string $expression, string ...$args)
+    {
+    }
+
     /**
      * Returns $expression with replaced placeholders.
      *
@@ -12,5 +41,41 @@ class SqlExpression
     public function compile()
     {
         return '';
+    }
+
+    /**
+     * Used by compile method to replace placeholders with values.
+     *
+     * @param array $matches Matches found by preg_replace.
+     *
+     * @return string
+     * @noinspection PhpMissingParamTypeInspection
+     * @noinspection PhpUnusedParameterInspection
+     */
+    protected function execPlaceholders($matches)
+    {
+        return '';
+    }
+
+    public function __toString()
+    {
+        return $this->compile();
+    }
+
+    /**
+     * @return Connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * @param Connection $connection
+     *
+     * @noinspection PhpMissingParamTypeInspection*/
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
     }
 }

--- a/src/main/Mock/Bitrix/Main/ORM/Fields/ExpressionField.php
+++ b/src/main/Mock/Bitrix/Main/ORM/Fields/ExpressionField.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace WebArch\BitrixTaxidermist\Mock\Bitrix\Main\ORM\Fields;
+
+use WebArch\BitrixTaxidermist\Mock\Bitrix\Main\SystemException;
+
+class ExpressionField extends Field implements IReadable
+{
+    /**
+     * @var ScalarField
+     */
+    protected $valueField;
+
+    /**
+     * All fields in exression should be placed as %s (or as another placeholder for sprintf),
+     * and the real field names being carrying in $buildFrom array (= args for sprintf)
+     *
+     * @param string $name
+     * @param string $expression
+     * @param null|array|string $buildFrom
+     * @param array $parameters deprecated, use configure* and add* instead
+     *
+     * @throws SystemException
+     * @noinspection PhpUnusedParameterInspection
+     * @noinspection PhpMissingParamTypeInspection
+     */
+    public function __construct($name, $expression, $buildFrom = null, $parameters = [])
+    {
+        parent::__construct($name, $parameters);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function cast($value)
+    {
+        $valueField = $this->valueField;
+        return $valueField->cast($value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function convertValueFromDb($value)
+    {
+        $valueField = $this->valueField;
+        return $valueField->convertValueFromDb($value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public function convertValueToDb($value)
+    {
+        /** @var IStorable $valueField */
+        $valueField = $this->valueField;
+        return $valueField->convertValueToDb($value);
+    }
+}

--- a/src/main/Mock/Bitrix/Main/ORM/Fields/Field.php
+++ b/src/main/Mock/Bitrix/Main/ORM/Fields/Field.php
@@ -14,11 +14,15 @@ abstract class Field
     /** @var Entity */
     protected $entity;
 
+    /** @var null|callback[] */
+    protected $saveDataModifiers;
+
     /**
      * @param string $name
      * @param array<string, mixed> $parameters deprecated, use configure* and add* methods instead
      *
      * @throws SystemException
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function __construct($name, $parameters = [])
     {
@@ -30,6 +34,7 @@ abstract class Field
      * @throws SystemException
      * @return Field
      * @noinspection PhpUnusedParameterInspection
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function addFetchDataModifier($modifier)
     {
@@ -59,5 +64,27 @@ abstract class Field
     public function getEntity()
     {
         return $this->entity;
+    }
+
+    /**
+     * @throws SystemException
+     * @return null|array|callback[]
+     */
+    public function getSaveDataModifiers()
+    {
+        return $this->saveDataModifiers;
+    }
+
+    /**
+     * @param $modifier
+     *
+     * @throws SystemException
+     * @return $this
+     * @noinspection PhpUnusedParameterInspection
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function addSaveDataModifier($modifier)
+    {
+        return $this;
     }
 }

--- a/src/main/Mock/Bitrix/Main/ORM/Fields/ScalarField.php
+++ b/src/main/Mock/Bitrix/Main/ORM/Fields/ScalarField.php
@@ -7,6 +7,8 @@ use WebArch\BitrixTaxidermist\Mock\Bitrix\Main\SystemException;
 
 abstract class ScalarField extends Field implements IStorable
 {
+    protected $column_name = '';
+
     /**
      * ScalarField constructor.
      *
@@ -14,6 +16,7 @@ abstract class ScalarField extends Field implements IStorable
      * @param array<string, mixed> $parameters deprecated, use configure* and add* methods instead
      *
      * @throws SystemException
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function __construct($name, $parameters = [])
     {
@@ -25,6 +28,7 @@ abstract class ScalarField extends Field implements IStorable
      *
      * @return $this
      * @noinspection PhpUnusedParameterInspection
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function configureRequired($value)
     {
@@ -44,6 +48,7 @@ abstract class ScalarField extends Field implements IStorable
      *
      * @return $this
      * @noinspection PhpUnusedParameterInspection
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function configureDefaultValue($value)
     {
@@ -55,6 +60,7 @@ abstract class ScalarField extends Field implements IStorable
      *
      * @return null|callable|mixed
      * @noinspection PhpUnusedParameterInspection
+     * @noinspection PhpDocSignatureInspection
      */
     public function getDefaultValue($row = null)
     {
@@ -73,5 +79,19 @@ abstract class ScalarField extends Field implements IStorable
         }
 
         return (strval($value) === '');
+    }
+
+    public function getColumnName()
+    {
+        return $this->column_name;
+    }
+
+    /**
+     * @param string $column_name
+     *
+     * @noinspection PhpMissingParamTypeInspection*/
+    public function setColumnName($column_name)
+    {
+        $this->column_name = $column_name;
     }
 }


### PR DESCRIPTION
Добавлено:
- Макет класса \Bitrix\Main\ORM\Fields\ExpressionField
- Расширены \Bitrix\Main\DB\SqlExpression, \Bitrix\Main\ORM\Fields\ScalarField,
  \WebArch\BitrixTaxidermist\Mock\Bitrix\Main\ORM\Fields\Field